### PR TITLE
 Fixed netbots_math.contains() for 0 to 0

### DIFF
--- a/src/netbots_math.py
+++ b/src/netbots_math.py
@@ -50,7 +50,7 @@ def contains(x1, y1, startRad, endRad, x2, y2):
     dist = 0
 
     a = angle(x1, y1, x2, y2)
-    if(startRad > endRad):  # if we are scanning clockwise over 0 radians.
+    if(startRad >= endRad):  # if we are scanning clockwise over 0 radians.
         if startRad <= a or a <= endRad:
             dist = distance(x1, y1, x2, y2)
     elif startRad <= a and a <= endRad:


### PR DESCRIPTION
**Description**
In netbots_math.contains() on line 53, the greater than sign has been changed to a greater than equals sign to accommodate angles starting at 0 and ending at 0.

**Motivation and Context**
Before netbots_math.contains() would not handle angles starting at 0 and ending at 0.  Now netbots_math.contains() works better in conjunction with netbots_math.normalizeAngle() as angles starting at 0 and ending at 2pi are normalized to 0 and 0.

**Related Issue(s)**

This commit resolves issue #36.

**Completeness**

This commit completely resolves the issue.

**Testing**

This fixes the error and does not cause any other issues.  Only more flexibility in starting and ending radians is introduced.

**Note**
I cannot seem to only include my changes to the src code.  The other pull requests need to be removed.