### PR TITLE
Fixing findOverlapingBots

### DIFF
--- a/src/netbots_server.py
+++ b/src/netbots_server.py
@@ -266,7 +266,7 @@ def findOverlapingBots(d, bots):
         if 'health' not in boti or boti['health'] is not 0:
             for j in range(i + 1, len(keys)):
                 botj = bots[keys[j]]
-                if 'health' not in boti or botj['health'] is not 0:
+                if 'health' not in botj or botj['health'] is not 0:
                     if nbmath.distance(boti['x'], boti['y'], botj['x'], botj['y']) <= d.conf['botRadius'] * 2:
                         return [keys[i], keys[j]]
 


### PR DESCRIPTION
**Description**

Line 269 has been fixed to properly check if the botj dictionary has the key 'health'.

**Motivation and Context**

Before there was a second check for boti having the key 'health' when it should have been for botj.  This would throw an error if botj had no 'health' key.

**Related Issue(s)**

"Add a more fair start state generator." commits.

**Completeness**

Properly checks that botj has a key of 'health'.

**Testing**

I have tested several games and there are no errors.